### PR TITLE
fix error using deprecated Now on page

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,7 +12,7 @@
             {{ if or (.Site.Params.copyright) (.Site.Params.credit) }}
             <div class="col-xs-12">
                 {{ if .Site.Params.copyright }}
-                Copyright &copy; {{ .Now.Format "2006" }} {{ .Site.Title }}.
+                Copyright &copy; {{ now.Format "2006" }} {{ .Site.Title }}.
                 {{ end }}
                 {{ if .Site.Params.credit }}
                 Theme developed by <a href="https://tomanistor.com">Toma Nistor</a>.


### PR DESCRIPTION
Hugo generates an error about Page's Now being deprecated on build:
`
ERROR 2017/07/02 15:42:48 Page's Now is deprecated and will be removed in Hugo 0.25. Use now (the template func).
`
