### PR TITLE
Added Mathjax-MathMLsupport (chrome friendly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Check original documentation for the parent theme below, this will be removed/edited soon
-
 ![Logo](https://github.com/tomanistor/osprey/blob/master/images/osprey-logo.png)
 
 # Osprey

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Check original documentation for the parent theme below, this will be removed/edited soon
+
 ![Logo](https://github.com/tomanistor/osprey/blob/master/images/osprey-logo.png)
 
 # Osprey

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,7 @@
         </main>
         <footer class="row middle-xs center-xs">
+            <script>window.MathJax = { MathML: { extensions: ["mml3.js", "content-mathml.js"]}};</script>
+            <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=MML_HTMLorMML"></script>
             {{ if .Site.Params.github }}
             <div class="col-xs-3 col-md-2"><a href="https://github.com/{{ .Site.Params.github }}">GitHub</a></div>
             {{ end }}


### PR DESCRIPTION
Sorry about the double pull request, the first was a mistake. Anyway we implemented mathjax in our fork because we wanted to use it in our blog posts. There are other Hugo themes that have it implemented by default as well so I thought this theme could benefit. 