### PR TITLE
Update header.html

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -71,7 +71,7 @@
 
         <link rel="canonical" href="{{ .Permalink }}">
         {{ if .RSSLink }}<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}">{{ end }}
-        <link rel="stylesheet" href="styles/{{ if .Site.Params.cacheBustCSS }}{{ index .Site.Data.styles.hash "main.css" }}{{ else }}main.css{{ end }}" type="text/css">
+        <link rel="stylesheet" href="{{ .Site.BaseURL }}styles/{{ if .Site.Params.cacheBustCSS }}{{ index .Site.Data.styles.hash "main.css" }}{{ else }}main.css{{ end }}" type="text/css">
         {{ if .Site.Params.customCSS }}{{ partial "css.html" . }}{{ end }}
         {{ if .Site.Params.highlightJS }}<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/github.min.css">{{ end }}
         {{ if .Site.GoogleAnalytics }}{{ template "_internal/google_analytics.html" . }}{{ end }}


### PR DESCRIPTION
Add {{ .Site.BaseURL }} to the stylesheet url to allow blog posts with subfolder in urls. Usefull to keep old urls after migration.