### PR TITLE
only include blog partial if any articles exist

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,9 @@
 
       {{ partial "about.html" . }}
       {{ partial "gallery.html" . }}
+      {{ if not (eq (len (where .Data.Pages "Section" "blog")) 0) }}
       {{ partial "blog.html" . }}
+      {{ end }}
       {{ partial "contact.html" . }}
 
     </main>


### PR DESCRIPTION
This is a trivial patch which improves the index rendering when there are no blog posts at all (yet) in the site's content, by omitting altogether the `blog.html` partial.

This makes it possible to use the nice Osprey theme for simple landing pages with no blog posts.